### PR TITLE
REP-3139 There are the updates required to operate with Repose v7.3.0.0.

### DIFF
--- a/extract-device-id/src/main/java/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilter.java
+++ b/extract-device-id/src/main/java/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilter.java
@@ -146,7 +146,7 @@ public class ExtractDeviceIdFilter implements Filter, UpdateListener<ExtractDevi
         maasServiceUri = configurationObject.getMaasServiceUri();
         cacheTimeoutMillis = configurationObject.getCacheTimeoutMillis();
         final AkkaServiceClient akkaServiceClientOld = akkaServiceClient;
-        akkaServiceClient = akkaServiceClientFactory.newAkkaServiceClient(configurationObject.getConnectionPoolId());
+        akkaServiceClient = akkaServiceClientFactory.newAkkaServiceClient();
         Optional.ofNullable(akkaServiceClientOld).ifPresent(AkkaServiceClient::destroy);
         initialized = true;
         LOG.trace("Extract Device ID filter was initialized.");

--- a/extract-device-id/src/main/resources/META-INF/schema/config/extract-device-id.xsd
+++ b/extract-device-id/src/main/resources/META-INF/schema/config/extract-device-id.xsd
@@ -29,15 +29,6 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation>
-                    <html:p>
-                        The Repose HTTP Connection Pool ID to use when talking to the Rackspace MaaS endpoint.
-                    </html:p>
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="cache-timeout-millis" type="extract-device-id:ZeroOrPositiveInteger" use="optional" default="0">
             <xs:annotation>
                 <xs:documentation>

--- a/extract-device-id/src/main/resources/META-INF/schema/config/extract-device-id.xsd
+++ b/extract-device-id/src/main/resources/META-INF/schema/config/extract-device-id.xsd
@@ -29,6 +29,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="connection-pool-id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <html:p>
+                        The Repose HTTP Connection Pool ID to use when talking to the Rackspace MaaS endpoint.
+                    </html:p>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="cache-timeout-millis" type="extract-device-id:ZeroOrPositiveInteger" use="optional" default="0">
             <xs:annotation>
                 <xs:documentation>

--- a/extract-device-id/src/main/resources/META-INF/schema/examples/extract-device-id.cfg.xml
+++ b/extract-device-id/src/main/resources/META-INF/schema/examples/extract-device-id.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <extract-device-id xmlns='http://docs.openrepose.org/repose/extract-device-id/v1.0'
-        maas-service-uri="http://www.maas.com"
-        cache-timeout-millis="0">
+                   maas-service-uri="http://www.maas.com"
+                   cache-timeout-millis="0">
     <delegating quality="0.2"/>
 </extract-device-id>

--- a/extract-device-id/src/test/groovy/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilterTest.groovy
+++ b/extract-device-id/src/test/groovy/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilterTest.groovy
@@ -91,7 +91,7 @@ public class ExtractDeviceIdFilterTest extends Specification {
         when(mockDatastoreService.defaultDatastore).thenReturn mockDatastore
         mockAkkaServiceClient = mock(AkkaServiceClient.class)
         mockAkkaServiceClientFactory = mock(AkkaServiceClientFactory.class)
-        when(mockAkkaServiceClientFactory.newAkkaServiceClient(anyString())).thenReturn mockAkkaServiceClient
+        when(mockAkkaServiceClientFactory.newAkkaServiceClient()).thenReturn mockAkkaServiceClient
         filter = new ExtractDeviceIdFilter(mockConfigService, mockAkkaServiceClientFactory, mockDatastoreService)
         config = new ExtractDeviceIdConfig()
         delegatingType = new DelegatingType()

--- a/extract-device-id/src/test/groovy/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilterTest.groovy
+++ b/extract-device-id/src/test/groovy/org/openrepose/filters/custom/extractdeviceid/ExtractDeviceIdFilterTest.groovy
@@ -38,6 +38,7 @@ import org.openrepose.core.services.datastore.Datastore
 import org.openrepose.core.services.datastore.DatastoreService
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClient
 import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientException
+import org.openrepose.core.services.serviceclient.akka.AkkaServiceClientFactory
 import org.openrepose.filters.custom.extractdeviceid.config.DelegatingType
 import org.openrepose.filters.custom.extractdeviceid.config.ExtractDeviceIdConfig
 import org.slf4j.LoggerFactory
@@ -75,6 +76,7 @@ public class ExtractDeviceIdFilterTest extends Specification {
     def Datastore mockDatastore
     def DatastoreService mockDatastoreService
     def AkkaServiceClient mockAkkaServiceClient
+    def AkkaServiceClientFactory mockAkkaServiceClientFactory
     def ConfigurationService mockConfigService
     def ListAppender listAppender
 
@@ -88,7 +90,9 @@ public class ExtractDeviceIdFilterTest extends Specification {
         mockDatastoreService = mock(DatastoreService.class)
         when(mockDatastoreService.defaultDatastore).thenReturn mockDatastore
         mockAkkaServiceClient = mock(AkkaServiceClient.class)
-        filter = new ExtractDeviceIdFilter(mockConfigService, mockAkkaServiceClient, mockDatastoreService)
+        mockAkkaServiceClientFactory = mock(AkkaServiceClientFactory.class)
+        when(mockAkkaServiceClientFactory.newAkkaServiceClient(anyString())).thenReturn mockAkkaServiceClient
+        filter = new ExtractDeviceIdFilter(mockConfigService, mockAkkaServiceClientFactory, mockDatastoreService)
         config = new ExtractDeviceIdConfig()
         delegatingType = new DelegatingType()
         delegatingType.quality = 0.9

--- a/functional-test/pom.xml
+++ b/functional-test/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>functional-test</artifactId>
 
     <properties>
-        <repose.version>7.2.2.0</repose.version>
+        <repose.version>7.3.0.0</repose.version>
 
         <!-- this is the version of artifacts to use from the published repose-support project -->
         <test.artifact.version>3.0</test.artifact.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.license>apache20</project.license>
         <project.inceptionYear>2010</project.inceptionYear>
-        <repose.version>7.2.2.0</repose.version>
+        <repose.version>7.3.0.0</repose.version>
         <groovy.version>2.1.3</groovy.version>
         <spock.version>0.7-groovy-2.0</spock.version>
         <gmaven.version>1.5</gmaven.version>


### PR DESCRIPTION
Since this filter is slightly coupled with the Repose internals, whenever a Major or Minor (first or second digit) release is made, there is a potential for incompatibilities. This is one of those cases where a Minor change would break this filter.